### PR TITLE
fix: booktab reference (fix #37)

### DIFF
--- a/changelog.typ
+++ b/changelog.typ
@@ -14,6 +14,13 @@
 #set list(indent: 0em)
 #set heading(numbering: none)
 
+== 2026-02-16 #contributors.lucifer1004 #pr(38)
+
++ 修复 `booktab` 无法被 `@label` 引用（"cannot reference styled"）的问题（#issue(37)）：
+  - 将表格字号设置移入块内部，避免返回的 `figure` 被包裹为 styled 导致不可引用。
+  - 明确了只有 `outlined = true` 时的 `booktab` 才能被引用，同时 `caption` 生效。
++ 取消了表格内部的 `top-edge: "ascender"` 设置，修复了表格内中英文字体对齐的问题（#issue(37)）。
+
 == 2026-01-27 #contributors.lucifer1004 #pr(36)
 
 + 更新 #link("https://github.com/pku-typst/gb7714-bilingual")[gb7714-bilingual] 包到 `v0.2.1`：

--- a/doc/ch03-basics.typ
+++ b/doc/ch03-basics.typ
@@ -178,9 +178,11 @@ Typst 中定义表格使用 `table` 函数。如需标题和引用功能，同�
 
 本模板提供了 `booktab` 函数用于生成更美观的三线表。`booktab` 基于原生 `table` 实现，支持大部分 `table` 参数（`stroke` 除外），第一行自动作为表头。
 
+*引用规则*：仅当 `outlined = true`（默认）时，`booktab` 才会包装为 `figure`，此时 `caption` 生效、表格可被 `@label` 引用。设 `outlined: false` 时为纯表格，`caption` 不生效，且不能使用 `@` 引用。
+
 *注意*：本模板默认允许表格跨页显示（`show figure: set block(breakable: true)`）。如果不希望某个表格被分割，可以在表格前手动插入 `#pagebreak()` 进行调整。
 
-三线表示例：
+@booktab-example 展示了 `booktab` 的示例效果：
 
 #code-preview(
   ```typ
@@ -383,6 +385,8 @@ gb7714-bilingual 会自动检测文献语言。如果自动检测不准确，可
 == 交叉引用
 
 Typst 使用标签 `<label>`（或`label(...)`）和引用 `@label`（或`link(dst, src)`）实现交叉引用。当原始标签引用的对象是章节、图表等时，`@label` 会自动转换为链接文本。对于一般的引用，则需要通过 `link` 函数手动创建链接文本。
+
+*图表与表格*：图片需放在 `figure` 中；`booktab` 表格需要使用 `outlined: true`（默认），才能用 `<label>` 配合 `@label` 引用。`outlined: false` 的纯表格不能作为引用目标。
 
 #code-preview(
   ```typ

--- a/lib/components.typ
+++ b/lib/components.typ
@@ -4,7 +4,7 @@
 #import "config.typ": (
   appendixcounter, chaptercounter, front-heading, partcounter, 字号, 引用记号,
 )
-#import "utils.typ": bodytotextwithtrim, chinesenumbering
+#import "utils.typ": caption-to-text, chinesenumbering
 
 // 中文目录
 // 使用 Typst 原生 outline + show rule 实现
@@ -126,7 +126,7 @@
     link(el_loc, maybe_number)
 
     // Caption 文本
-    link(el_loc, bodytotextwithtrim(el.caption.body))
+    link(el_loc, caption-to-text(el.caption))
 
     // 填充点
     box(width: 1fr, [#h(2pt) #box(width: 1fr, repeat[.]) #h(2pt)])
@@ -160,22 +160,22 @@
 //
 // booktab 专用参数:
 //   width: 表格外层容器宽度，默认 auto
-//   caption: 表格标题（设为 none 且 outlined 为 false 时不使用 figure）
-//   outlined: 是否包装在 figure 中（默认 true），设为 false 时生成纯表格
+//   outlined: 是否包装在 figure 中（默认 true）。仅当 outlined = true 时 caption 生效，且表格可被 @label 引用；设为 false 时生成纯表格，无标题、不可引用。
+//   caption: 表格标题，仅在 outlined = true 时生效（出现在表格列表、可作为引用目标）
 //
 // 必须指定 columns 参数（用于分离表头行），其他参数直接传递给 table
 // stroke 参数会被忽略（三线表有固定的线条样式）
 //
 // 用法:
-//   // 带标题的表格（出现在表格列表中）
+//   // 带标题的表格（outlined 默认 true，出现在表格列表中，可被 @label 引用）
 //   #booktab(
 //     columns: 3,
-//     caption: "示例表格",
+//     caption: [示例表格],
 //     [表头1], [表头2], [表头3],
 //     [内容1], [内容2], [内容3],
-//   )
+//   ) <tab-label>
 //
-//   // 纯表格（不带标题和编号）
+//   // 纯表格（outlined: false，不带标题和编号，不可引用）
 //   #booktab(
 //     columns: 2,
 //     outlined: false,
@@ -203,26 +203,27 @@
   // 移除 stroke（三线表固定样式）
   let _ = table-args.remove("stroke", default: none)
 
-  set text(字号.表文, top-edge: "ascender")
-
   let the-table = block(
     width: width,
     breakable: true,
-    table(
-      stroke: none,
-      ..table-args,
-      // 表头行
-      table.hline(stroke: 1.5pt),
-      ..headers.map(strong),
-      table.hline(stroke: 0.75pt),
-      // 内容行
-      ..contents,
-      table.hline(stroke: 1.5pt),
-    ),
+    {
+      set text(字号.表文)
+      table(
+        stroke: none,
+        ..table-args,
+        // 表头行
+        table.hline(stroke: 1.5pt),
+        ..headers.map(strong),
+        table.hline(stroke: 0.75pt),
+        // 内容行
+        ..contents,
+        table.hline(stroke: 1.5pt),
+      )
+    },
   )
 
   if outlined {
-    figure(the-table, caption: caption, kind: table)
+    figure(the-table, caption: caption, outlined: outlined, kind: table)
   } else {
     the-table
   }

--- a/lib/utils.typ
+++ b/lib/utils.typ
@@ -72,11 +72,20 @@
   }
 }
 
-// 从 figure caption body 中提取文本
-#let bodytotextwithtrim(a) = {
-  if a.has("children") {
-    let found = a.children.find(it => it.has("text") and it.text.len() > 0)
-    if found != none { found } else { a }
+// 从 figure caption 中提取用于列表条目链接的显示内容。
+// 输入为 str 时返回 trim 后的字符串；为 content 时先按 .body 递归解包，再若有 .children 则取第一个含非空 .text 的子节点，否则返回原 content。供 listoffigures 等用作 link 的显示文本。
+#let caption-to-text(a) = {
+  if type(a) == str {
+    a.trim()
+  } else if type(a) == content {
+    if a.has("body") {
+      caption-to-text(a.body)
+    } else if a.has("children") {
+      let found = a.children.find(it => it.has("text") and it.text.len() > 0)
+      if found != none { found } else { a }
+    } else {
+      a
+    }
   } else {
     a
   }

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modern-pku-thesis"
-version = "0.2.1"
+version = "0.2.2"
 entrypoint = "template.typ"
 authors = ["Gabriel Wu <@lucifer1004>"]
 license = "MIT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Captioned tables can now be referenced by label (@label) as expected.
  * Fixed alignment between Chinese and English text in tables.
  * Adjusted table rendering so captioned tables are wrapped as figures and text sizing aligns correctly.

* **Documentation**
  * Added guidance on table citation rules and cross-reference requirements for charts and tables.
  * Included a concrete example demonstrating captioned booktab usage with labels.

* **Chores**
  * Version bumped to 0.2.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->