### PR TITLE
Fix codeblock function to handle caption display

### DIFF
--- a/lib/components.typ
+++ b/lib/components.typ
@@ -143,16 +143,21 @@
 
 // 代码块组件
 // 用法: #codeblock(```python ... ```, caption: "示例代码")
+// 省略 caption 时仅显示代码，不编号、不入代码列表、不可引用
 #let codeblock(raw, caption: none) = {
-  figure(
-    {
-      set align(left)
-      raw
-    },
-    caption: caption,
-    kind: "code",
-    supplement: "",
-  )
+  if caption != none {
+    figure(
+      {
+        set align(left)
+        raw
+      },
+      caption: caption,
+      kind: "code",
+      supplement: "",
+    )
+  } else {
+    raw
+  }
 }
 
 // 三线表组件


### PR DESCRIPTION
OS: Linux x64 7.1.5-arch1-2
Typst: 0.15.1
Description: Omitting the caption of the code block will result in an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Captionless code blocks now display directly without unnecessary figure wrappers, numbering, list entries, or citation references.
  * Code blocks with captions continue to support figure behavior and related references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->